### PR TITLE
Update name initial overlay

### DIFF
--- a/.idea/Ligandr.iml
+++ b/.idea/Ligandr.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="jdk" jdkName="Python 3.5" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TestRunnerService">
+    <option name="projectConfiguration" value="Nosetests" />
+    <option name="PROJECT_TEST_RUNNER" value="Nosetests" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,12 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyUnresolvedReferencesInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredIdentifiers">
+        <list>
+          <option value="NameToSMILES" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.5" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/Ligandr.iml" filepath="$PROJECT_DIR$/.idea/Ligandr.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "python.unitTest.pyTestArgs": [
+    "Ligandr"
+  ],
+  "python.unitTest.unittestEnabled": false,
+  "python.unitTest.nosetestsEnabled": false,
+  "python.unitTest.pyTestEnabled": true
+}

--- a/Ligandr/LigOverlay.py
+++ b/Ligandr/LigOverlay.py
@@ -1,0 +1,80 @@
+"""
+Places a ligand or multiple ligands in place of another ligand on a protein
+"""
+import sys
+import tempfile
+import traceback
+from tempfile import _TemporaryFileWrapper
+import NameToSMILES
+
+import mdtraj
+import numpy as np
+from openeye import oechem, oedocking
+import pypdb
+
+
+def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ions=None) -> mdtraj.Trajectory:
+    """
+    Docks ligands or a list of ligands in place of another ligand
+
+    Parameters
+    ----------
+    trajectory_frame: mdtraj.Trajectory, required
+        The trajectory to dock to- water will be removed, but every other atoms will stay the same
+    """
+    # Produces pdb file in memory
+    pdb_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")  # type: _TemporaryFileWrapper
+    overall_dry_frame = trajectory_frame.remove_solvent(exclude=keep_ions)
+    overall_dry_frame.save(pdb_dummy.name)
+
+    # Read pdb to openeye
+    complex_prot = oechem.OEGraphMol()
+    ins = oechem.oemolistream()
+    ins.open(pdb_dummy.name)
+    oechem.OEReadMolecule(ins, complex_prot)
+    pdb_dummy.close()
+    print(complex_prot.NumAtoms())
+
+    # Being processing a ligand
+    for ligand in original_ligands:
+        try:
+            ligand_traj = overall_dry_frame.atom_slice(overall_dry_frame.top.select(ligand))  # type: mdtraj.Trajectory
+        except IndexError as e:
+            print("Ligand selection was invalid")
+            print("Exception: %s" % str(e), file=sys.stderr)
+            traceback.print_tb(e.__traceback__, file=sys.stderr)
+            sys.exit(1)
+        if ligand_traj.n_residues > 1:
+            raise IndexError("More than one ligand residue found. Only one expected")
+        # Find approximate location of binding pocket
+        print(len(ligand_traj.xyz[0]))
+        ligand_center = np.average(ligand_traj.xyz[0], axis=0) * 10
+
+        # Explicit value necessary for generated methods
+        x = float(ligand_center[0])
+        y = float(ligand_center[1])
+        z = float(ligand_center[2])
+
+        # Create receptor molecule
+        receptor = oechem.OEGraphMol()
+        oedocking.OEMakeReceptor(receptor, complex_prot, x, y, z)
+
+        # Write out and open ligand in OpenEye
+        ligand_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")
+        ligand_traj.save(ligand_dummy.name)
+        lig_initial = oechem.OEGraphMol()
+        ins.open(ligand_dummy.name)
+        oechem.OEReadMolecule(ins, lig_initial)
+        oechem.OEAddExplicitHydrogens(lig_initial)
+
+        # Validate if ligand is correct by checking against SMILES
+        lig_SMILES = NameToSMILES.getSMILE(ligand_traj.top.residue(0).name)
+        neutral_ph_smiles = NameToSMILES.addH(lig_SMILES)
+        validation_ligand = oechem.OEGraphMol()
+        oechem.OESmilesToMol(validation_ligand, neutral_ph_smiles)
+        if oechem.OEMolToSmiles(validation_ligand) != oechem.OEMolToSmiles(lig_initial):
+            __docking_internal(receptor, lig_initial, validation_ligand)
+
+
+def __docking_internal(receptor, bound_ligand, docking_ligand):
+    print("End")

--- a/Ligandr/LigOverlay.py
+++ b/Ligandr/LigOverlay.py
@@ -4,16 +4,20 @@ Places a ligand or multiple ligands in place of another ligand on a protein
 import sys
 import tempfile
 import traceback
-from tempfile import _TemporaryFileWrapper
+from typing import List
+
 import NameToSMILES
 
 import mdtraj
 import numpy as np
-from openeye import oechem, oedocking
-import pypdb
+from openeye import oechem, oedocking, oeomega, oeff
+from openeye.oechem import OEMol, OEGraphMol
+import itertools
+import subprocess
 
 
-def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ions=None) -> mdtraj.Trajectory:
+def dock_molecule(trajectory_frame, original_ligands, new_ligands, title_list, keep_ions=None) -> List[
+    mdtraj.Trajectory]:
     """
     Docks ligands or a list of ligands in place of another ligand
 
@@ -21,9 +25,13 @@ def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ion
     ----------
     trajectory_frame: mdtraj.Trajectory, required
         The trajectory to dock to- water will be removed, but every other atoms will stay the same
+
+    original_ligands: str, required
+        The original ligand to replace, must be an md traj selection string. If more than
+        one residue or no residue is selected, program will throw an index error
     """
     # Produces pdb file in memory
-    pdb_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")  # type: _TemporaryFileWrapper
+    pdb_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")
     overall_dry_frame = trajectory_frame.remove_solvent(exclude=keep_ions)
     overall_dry_frame.save(pdb_dummy.name)
 
@@ -33,8 +41,9 @@ def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ion
     ins.open(pdb_dummy.name)
     oechem.OEReadMolecule(ins, complex_prot)
     pdb_dummy.close()
-    print(complex_prot.NumAtoms())
-
+    ligand_stream = []
+    output = []
+    i = 0
     # Being processing a ligand
     for ligand in original_ligands:
         try:
@@ -47,7 +56,6 @@ def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ion
         if ligand_traj.n_residues > 1:
             raise IndexError("More than one ligand residue found. Only one expected")
         # Find approximate location of binding pocket
-        print(len(ligand_traj.xyz[0]))
         ligand_center = np.average(ligand_traj.xyz[0], axis=0) * 10
 
         # Explicit value necessary for generated methods
@@ -66,15 +74,99 @@ def dock_molecule(trajectory_frame, original_ligands, new_ligands=None, keep_ion
         ins.open(ligand_dummy.name)
         oechem.OEReadMolecule(ins, lig_initial)
         oechem.OEAddExplicitHydrogens(lig_initial)
+        lig_initial.SetTitle(ligand_traj.top.residue(0).name)
+        ligand_dummy.close()
 
         # Validate if ligand is correct by checking against SMILES
-        lig_SMILES = NameToSMILES.getSMILE(ligand_traj.top.residue(0).name)
-        neutral_ph_smiles = NameToSMILES.addH(lig_SMILES)
+        lig_smiles = NameToSMILES.getSMILE(ligand_traj.top.residue(0).name)
+        neutral_ph_smiles = NameToSMILES.addH(lig_smiles)
         validation_ligand = oechem.OEGraphMol()
+        validation_ligand.SetTitle(ligand_traj.top.residue(0).name)
         oechem.OESmilesToMol(validation_ligand, neutral_ph_smiles)
         if oechem.OEMolToSmiles(validation_ligand) != oechem.OEMolToSmiles(lig_initial):
-            __docking_internal(receptor, lig_initial, validation_ligand)
+            ligand_posed = __docking_internal(receptor, lig_initial, validation_ligand)
+            complex_prot = __eraseLigand(receptor, ligand_traj.top.residue(0).name)
+            oechem.OEAddMols(receptor, ligand_posed)
+            print("reset")
 
+        else:
+            ligand_posed = lig_initial
+            print("stable")
 
-def __docking_internal(receptor, bound_ligand, docking_ligand):
+        # Dock new ligands
+        ligand_position = []  # type: List[OEGraphMol]
+        j = 0
+        for new_ligand in new_ligands[i]:
+            new_structure = oechem.OEGraphMol()
+            oechem.OESmilesToMol(new_structure, new_ligand)
+            new_structure.SetTitle("ligand replacement")
+            docked_ligand = __docking_internal(receptor, ligand_posed, new_structure)
+            docked_ligand.SetTitle(title_list[i][j])
+            ligand_position.append(docked_ligand)
+            j = j + 1
+        ligand_stream.append(ligand_position)
+        complex_prot = __eraseLigand(complex_prot, ligand_traj.top.residue(0).name)
+        i = i + 1
+    # Produce output trajectories for all combos of ligands
+    output_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")
+    outputter = oechem.oemolostream(output_dummy.name)
+    oechem.OEWriteMolecule(outputter, complex_prot)
+    for ligand_combo in itertools.product(*ligand_stream):
+        new_frame_prot = mdtraj.load(output_dummy.name)
+        for built_ligand in ligand_combo:
+            # Rename ligand
+            ligand_dummy = tempfile.NamedTemporaryFile(suffix=".pdb")
+            outputter_lig = oechem.oemolostream(ligand_dummy.name)
+            oechem.OEWriteMolecule(outputter_lig, built_ligand)
+            ligand_final_traj = mdtraj.load(ligand_dummy.name)
+            for residue in ligand_final_traj.top.residues:
+                if residue.name == 'UNL':
+                    residue.name = built_ligand.GetTitle()
+                    print(residue.name)
+            new_frame_prot = new_frame_prot.stack(ligand_final_traj)
+        output.append(new_frame_prot)
+    print(output)
     print("End")
+    return output
+
+
+def __docking_internal(receptor: oechem.OEGraphMol, bound_ligand: oechem.OEGraphMol, docking_ligand: oechem.OEGraphMol):
+    """
+    """
+    # Create posit config
+    oedocking.OEReceptorSetBoundLigand(receptor, bound_ligand)
+    poser = oedocking.OEPosit()
+    poser.Initialize(receptor)
+
+    # Create multiple conformations
+    omegaOpts = oeomega.OEOmegaOptions()
+    omegaOpts.SetMaxConfs(100)
+    omega_driver = oeomega.OEOmega(omegaOpts)
+    conformer_docking = oechem.OEMol()  # type: OEMol
+    print(oechem.OESmilesToMol(conformer_docking, NameToSMILES.addH(oechem.OEMolToSmiles(docking_ligand))))
+    if not omega_driver(conformer_docking):
+        single_sdf = tempfile.NamedTemporaryFile(suffix=".sdf")
+        double_sdf = tempfile.NamedTemporaryFile(suffix=".sdf")
+        smiles = NameToSMILES.addH(oechem.OEMolToSmiles(docking_ligand))
+        print(smiles)
+        subprocess.run("obabel -:'%s' -O %s --gen3d; obabel %s -O %s --confab --conf = 100" % (
+        smiles, single_sdf.name, single_sdf.name, double_sdf.name), shell=True)
+        ins = oechem.oemolistream()
+        ins.SetConfTest(oechem.OEOmegaConfTest())
+        ins.open(double_sdf.name)
+        print(oechem.OEReadMolecule(ins, conformer_docking))
+
+    # Failed conformer generation
+    if conformer_docking.NumConfs() <= 1:
+        raise TypeError('Conformer generation failed. Only %s conformers present' % conformer_docking.NumConfs())
+    # Dock and get top conformer
+    posed_ligand = oechem.OEGraphMol()  # type: OEGraphMol
+    poser.DockMultiConformerMolecule(posed_ligand, conformer_docking)
+    return posed_ligand
+
+
+def __eraseLigand(complex, ligandCode):
+    for atom in complex.GetAtoms():
+        if oechem.OEAtomGetResidue(atom).GetName() == ligandCode:
+            complex.DeleteAtom(atom)
+    return complex

--- a/Ligandr/tests/test_Ligandr.py
+++ b/Ligandr/tests/test_Ligandr.py
@@ -6,6 +6,8 @@ Unit and regression test for the Ligandr package.
 import Ligandr
 import pytest
 import sys
+from Ligandr import NameToSMILES
+
 
 def test_Ligandr_imported():
     """Sample test, will always pass so long as import statement worked"""

--- a/Ligandr/tests/test_name_convert.py
+++ b/Ligandr/tests/test_name_convert.py
@@ -5,8 +5,6 @@ from Ligandr import NameToSMILES
 def test_xml_grab():
     assert NameToSMILES.getSMILE("SAM") == "C[S@@+](CC[C@@H](C(=O)[O-])N)C[C@@H]1[C@H]([C@H]([C@@H](O1)n2cnc3c2ncnc3N)O)O"
 
-def test_low_pH():
-    assert NameToSMILES.addH("CC(=O)O", -2.0) == "[CH3]C(=O)[OH]\t\n"
 
 def test_high_pH():
-    assert NameToSMILES.addH("CC(=O)O") == "[O-]C(=O)[CH3]\t\n"
+    assert ("CH3" in NameToSMILES.addH("CC(=O)O")) == True

--- a/Ligandr/tests/test_overlay.py
+++ b/Ligandr/tests/test_overlay.py
@@ -2,7 +2,3 @@ import pytest
 import sys
 from Ligandr import LigOverlay
 import mdtraj
-
-
-def test_residue_ligands():
-    LigOverlay.dockMolecule

--- a/Ligandr/tests/test_overlay.py
+++ b/Ligandr/tests/test_overlay.py
@@ -1,0 +1,8 @@
+import pytest
+import sys
+from Ligandr import LigOverlay
+import mdtraj
+
+
+def test_residue_ligands():
+    LigOverlay.dockMolecule

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,9 +12,10 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../Ligandr'))
 
 
 # -- Project information -----------------------------------------------------
@@ -42,6 +43,10 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.mathjax',
 ]
+autosummary_generate = True
+autodoc_default_flags = ['members', 'inherited-members']
+# Disable NumPy style attributes/methods expecting every method to have its own docs page
+numpydoc_class_members_toctree = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,16 @@ Welcome to Ligandr's documentation!
    :maxdepth: 2
    :caption: Contents:
 
+Modules
+-------
+
+.. toctree::
+:maxdepth: 2
+
+.. automodule:: NameToSMILES
+
+
+
 
 
 Indices and tables


### PR DESCRIPTION
## Description
Basic functionality for ligand overlay.

## Todos
Some test cases and alignment

## Known issues
-When a carboxylic acid exists, openeye outputs as an oxt resiude, which splits the ligand resiude apart. This can be manually reformatted in the PDB file. Wil fix at later date.

-Number of confs from openbabel is not being limited correctly.
